### PR TITLE
Add WSL support to setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ irm https://raw.githubusercontent.com/mylee04/claude-notify/main/install-windows
 
 > **Note**: Windows support is experimental and hasn't been fully tested yet. If you're a Windows user, please [report any issues](https://github.com/mylee04/claude-notify/issues) or let me know if it works! Your feedback will help improve Windows support. 🙏
 
+#### WSL (Windows Subsystem for Linux)
+```bash
+# Clone and install
+git clone https://github.com/mylee04/claude-notify.git
+cd claude-notify
+./install.sh
+```
+
 #### Linux (Bash)
 ```bash
 # Download and run the installer

--- a/lib/claude-notify/utils/detect.sh
+++ b/lib/claude-notify/utils/detect.sh
@@ -22,10 +22,19 @@ detect_claude_code() {
     return 1
 }
 
-# Detect if terminal-notifier is installed
+# Detect if terminal-notifier is installed (macOS)
 detect_terminal_notifier() {
     if command -v terminal-notifier &> /dev/null; then
         echo "$(which terminal-notifier)"
+        return 0
+    fi
+    return 1
+}
+
+# Detect if wsl-notify-send.exe is installed (WSL)
+detect_wsl_notify_send() {
+    if command -v wsl-notify-send.exe &> /dev/null; then
+        echo "$(which wsl-notify-send.exe)"
         return 0
     fi
     return 1


### PR DESCRIPTION
## Problem
`claude-notify setup` only checks for macOS `terminal-notifier` and does not detect WSL environment.
WSL users are incorrectly prompted to install `terminal-notifier` via Homebrew.

## Solution
- Add `detect_wsl_notify_send` function in detect.sh
- Detect WSL environment via `/proc/version` in setup command
- Prompt `wsl-notify-send.exe` installation for WSL users
- Add WSL section to README.md