### PR TITLE
Fix ANSI escape code rendering in help and status output

### DIFF
--- a/lib/claude-notify/utils/colors.sh
+++ b/lib/claude-notify/utils/colors.sh
@@ -5,23 +5,23 @@
 # Check if terminal supports colors
 if [[ -t 1 ]] && [[ "$(tput colors)" -ge 8 ]]; then
     # Regular Colors
-    BLACK='\033[0;30m'
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-    YELLOW='\033[0;33m'
-    BLUE='\033[0;34m'
-    PURPLE='\033[0;35m'
-    CYAN='\033[0;36m'
-    WHITE='\033[0;37m'
+    BLACK=$'\033[0;30m'
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[0;33m'
+    BLUE=$'\033[0;34m'
+    PURPLE=$'\033[0;35m'
+    CYAN=$'\033[0;36m'
+    WHITE=$'\033[0;37m'
     
     # Bold
-    BOLD='\033[1m'
+    BOLD=$'\033[1m'
     
     # Dim
-    DIM='\033[2m'
+    DIM=$'\033[2m'
     
     # Reset
-    RESET='\033[0m'
+    RESET=$'\033[0m'
     
     # Emojis for status
     CHECK_MARK="✅"


### PR DESCRIPTION
## Summary
- Fixed raw ANSI escape codes appearing in help command output
- Fixed color rendering in status command and setup wizard
- Changed color variable definitions to use ANSI-C quoting (`$'...'`) instead of single quotes

## Problem
Color variables were defined with single quotes (e.g., `CYAN='\033[0;36m'`), which created literal backslash strings instead of actual escape sequences. This caused raw escape codes like `\033[0;36mcn on\033[0m` to appear in terminal output.

## Solution
Updated all color definitions in `lib/claude-notify/utils/colors.sh` to use ANSI-C quoting (`$'...'`), which interprets escape sequences at assignment time.

## Test plan
- [x] `claude-notify help` displays properly formatted colored output
- [x] `claude-notify status` shows colored status indicators
- [x] Setup wizard "Quick commands" section renders colors correctly
- [x] All other commands display colors properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)