### PR TITLE
Fix sound setting ignored in send_macos_notification

### DIFF
--- a/lib/code-notify/core/notifier.sh
+++ b/lib/code-notify/core/notifier.sh
@@ -190,17 +190,26 @@ send_macos_notification() {
     bundle_id=$(get_terminal_bundle_id)
 
     if command -v terminal-notifier &> /dev/null; then
+        # Only pass -sound if sound is enabled; terminal-notifier always plays sound when -sound is set
+        local sound_args=()
+        if should_play_sound; then
+            sound_args=(-sound "$SOUND")
+        fi
         terminal-notifier \
             -title "$TITLE" \
             -subtitle "$SUBTITLE" \
             -message "$MESSAGE" \
-            -sound "$SOUND" \
+            "${sound_args[@]}" \
             -group "code-notify-$TOOL_NAME-$PROJECT_NAME" \
             -activate "$bundle_id" \
             2>/dev/null
     else
         # osascript doesn't support click-to-activate, but we can use a workaround
-        osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\" subtitle \"$SUBTITLE\" sound name \"$SOUND\"" 2>/dev/null
+        if should_play_sound; then
+            osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\" subtitle \"$SUBTITLE\" sound name \"$SOUND\"" 2>/dev/null
+        else
+            osascript -e "display notification \"$MESSAGE\" with title \"$TITLE\" subtitle \"$SUBTITLE\"" 2>/dev/null
+        fi
     fi
 }
 


### PR DESCRIPTION
## Problem

`cn sound off` has no effect on macOS. The `send_macos_notification` function always passes `-sound "$SOUND"` to `terminal-notifier`, which unconditionally plays a sound. The existing `should_play_sound` check only gated a separate `play_sound` call, not the sound embedded in the notification itself.

The same issue exists in the `osascript` fallback path.

## Fix

Gate the `-sound` argument on `should_play_sound()` for both `terminal-notifier` and `osascript` paths, matching the pattern already used for the standalone `play_sound` call.

## Testing

- `cn sound off` then trigger a notification → silent ✅
- `cn sound on` then trigger a notification → plays sound ✅