### PR TITLE
fix: keep Codex notify at TOML top-level

### DIFF
--- a/lib/code-notify/core/config.sh
+++ b/lib/code-notify/core/config.sh
@@ -77,6 +77,100 @@ atomic_write() {
     fi
 }
 
+# Escape a string for use inside a TOML basic string.
+toml_escape_string() {
+    local str="$1"
+    str="${str//\\/\\\\}"
+    str="${str//\"/\\\"}"
+    printf '%s' "$str"
+}
+
+# Check whether a key exists at TOML top-level (before the first table header).
+toml_has_top_level_key() {
+    local file="$1"
+    local key="$2"
+
+    if [[ ! -f "$file" ]]; then
+        return 1
+    fi
+
+    awk -v key="$key" '
+        $0 ~ /^[[:space:]]*\[/ {
+            exit(found ? 0 : 1)
+        }
+        $0 ~ ("^[[:space:]]*" key "[[:space:]]*=") {
+            found = 1
+        }
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "$file"
+}
+
+# Insert Code-Notify's top-level notify key before the first TOML table.
+upsert_codex_notify_config() {
+    local file="$1"
+    local notify_line="$2"
+    local dir_path
+    local tmp_file
+
+    dir_path=$(dirname "$file")
+    tmp_file=$(mktemp "${dir_path}/.tmp.XXXXXX") || return 1
+
+    awk -v comment_line="# Code-Notify: Desktop notifications" -v notify_line="$notify_line" '
+        /^[[:space:]]*# Code-Notify: Desktop notifications[[:space:]]*$/ {
+            next
+        }
+        /^[[:space:]]*notify[[:space:]]*=/ {
+            next
+        }
+        !inserted && $0 ~ /^[[:space:]]*\[/ {
+            while (prefix_count > 0 && prefix[prefix_count] ~ /^[[:space:]]*$/) {
+                prefix_count--
+            }
+            for (i = 1; i <= prefix_count; i++) {
+                print prefix[i]
+            }
+            if (prefix_count > 0) {
+                print ""
+            }
+            print comment_line
+            print notify_line
+            print ""
+            print
+            inserted = 1
+            next
+        }
+        !inserted {
+            prefix[++prefix_count] = $0
+            next
+        }
+        {
+            print
+        }
+        END {
+            if (!inserted) {
+                while (prefix_count > 0 && prefix[prefix_count] ~ /^[[:space:]]*$/) {
+                    prefix_count--
+                }
+                for (i = 1; i <= prefix_count; i++) {
+                    print prefix[i]
+                }
+                if (prefix_count > 0) {
+                    print ""
+                }
+                print comment_line
+                print notify_line
+            }
+        }
+    ' "$file" > "$tmp_file" || {
+        rm -f "$tmp_file"
+        return 1
+    }
+
+    mv "$tmp_file" "$file"
+}
+
 # Safe jq update helper - applies jq filter and only writes on success
 # Usage: safe_jq_update <file> <jq_filter> [--arg name value]...
 # Returns 0 on success, 1 on failure (original file unchanged)
@@ -579,34 +673,27 @@ is_enabled_project_settings() {
 
 # Check if Codex notifications are enabled
 is_codex_enabled() {
-    if [[ ! -f "$CODEX_CONFIG_FILE" ]]; then
-        return 1
-    fi
-    grep -qE '^notify\s*=' "$CODEX_CONFIG_FILE" 2>/dev/null
+    toml_has_top_level_key "$CODEX_CONFIG_FILE" "notify"
 }
 
 # Enable Codex notifications
 enable_codex_hooks() {
     local notify_script=$(get_notify_script)
+    local escaped_notify_script
+    local notify_line
 
     # Ensure .codex directory exists
     mkdir -p "$CODEX_HOME"
+
+    escaped_notify_script=$(toml_escape_string "$notify_script")
+    notify_line="notify = [\"bash\", \"-c\", \"$escaped_notify_script stop codex\"]"
 
     # Check if config.toml exists
     if [[ -f "$CODEX_CONFIG_FILE" ]]; then
         # Backup existing config
         backup_config "$CODEX_CONFIG_FILE"
 
-        # Remove existing notify line if present
-        if grep -qE '^notify\s*=' "$CODEX_CONFIG_FILE"; then
-            sed -i.bak '/^notify\s*=/d' "$CODEX_CONFIG_FILE"
-            rm -f "$CODEX_CONFIG_FILE.bak"
-        fi
-
-        # Append notify setting
-        echo "" >> "$CODEX_CONFIG_FILE"
-        echo "# Code-Notify: Desktop notifications" >> "$CODEX_CONFIG_FILE"
-        echo "notify = [\"bash\", \"-c\", \"$notify_script stop codex\"]" >> "$CODEX_CONFIG_FILE"
+        upsert_codex_notify_config "$CODEX_CONFIG_FILE" "$notify_line"
     else
         # Create new config.toml
         cat > "$CODEX_CONFIG_FILE" << EOF
@@ -614,7 +701,7 @@ enable_codex_hooks() {
 # https://developers.openai.com/codex/config-reference/
 
 # Code-Notify: Desktop notifications
-notify = ["bash", "-c", "$notify_script stop codex"]
+notify = ["bash", "-c", "$escaped_notify_script stop codex"]
 EOF
     fi
 }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -151,6 +151,60 @@ function Backup-ConfigFile {
     Copy-Item $Path (Join-Path $backupDir "$safeName.$timestamp.bak") -ErrorAction SilentlyContinue
 }
 
+function Test-TomlTopLevelKey {
+    param(
+        [string]$Path,
+        [string]$Key
+    )
+
+    if (-not (Test-Path $Path)) {
+        return $false
+    }
+
+    $content = Get-Content $Path -Raw
+    $match = [regex]::Match($content, "(?m)^\\s*\\[")
+    $prefix = if ($match.Success) { $content.Substring(0, $match.Index) } else { $content }
+
+    return [bool]([regex]::IsMatch($prefix, "(?m)^\\s*$([regex]::Escape($Key))\\s*="))
+}
+
+function Set-CodexNotifyConfig {
+    param(
+        [string]$Path,
+        [string]$NotifyLine
+    )
+
+    $commentLine = "# Code-Notify: Desktop notifications"
+
+    if (Test-Path $Path) {
+        $content = Get-Content $Path -Raw
+    } else {
+        $content = "# Codex CLI Configuration`n# https://developers.openai.com/codex/config-reference/"
+    }
+
+    $content = (($content -split "`r?`n") | Where-Object {
+        $_ -notmatch '^\s*# Code-Notify: Desktop notifications\s*$' -and $_ -notmatch '^\s*notify\s*='
+    }) -join "`n"
+    $content = $content.TrimEnd()
+
+    $tableMatch = [regex]::Match($content, '(?m)^\s*\[')
+    if ($tableMatch.Success) {
+        $prefix = $content.Substring(0, $tableMatch.Index).TrimEnd()
+        $suffix = $content.Substring($tableMatch.Index)
+        if ($prefix) {
+            $content = "$prefix`n`n$commentLine`n$NotifyLine`n`n$suffix"
+        } else {
+            $content = "$commentLine`n$NotifyLine`n`n$suffix"
+        }
+    } elseif ($content) {
+        $content = "$content`n`n$commentLine`n$NotifyLine"
+    } else {
+        $content = "$commentLine`n$NotifyLine"
+    }
+
+    Set-Content $Path -Value $content -Encoding UTF8
+}
+
 function Test-GitInstalled {
     $null = Get-Command git -ErrorAction SilentlyContinue
     return $?
@@ -431,7 +485,7 @@ function Test-NotificationsEnabled {
                 return $false
             }
 
-            return [bool](Select-String -Path $script:CodexConfigFile -Pattern '^\s*notify\s*=' -Quiet)
+            return Test-TomlTopLevelKey -Path $script:CodexConfigFile -Key "notify"
         }
         "gemini" {
             if ($Project -or -not (Test-Path $script:GeminiSettingsFile)) {
@@ -482,24 +536,7 @@ function Enable-Notifications {
 
             $escapedNotifyScript = $notifyScript -replace '\\', '\\\\'
             $notifyLine = 'notify = ["powershell", "-ExecutionPolicy", "Bypass", "-File", "' + $escapedNotifyScript + '", "stop", "codex"]'
-            $content = @()
-
-            if (Test-Path $script:CodexConfigFile) {
-                $content = @(Get-Content $script:CodexConfigFile | Where-Object {
-                    $_ -notmatch '^\s*# Code-Notify: Desktop notifications' -and $_ -notmatch '^\s*notify\s*='
-                })
-            } else {
-                $content += "# Codex CLI Configuration"
-                $content += "# https://developers.openai.com/codex/config-reference/"
-            }
-
-            if ($content.Count -gt 0) {
-                $content += ""
-            }
-            $content += "# Code-Notify: Desktop notifications"
-            $content += $notifyLine
-
-            $content | Set-Content $script:CodexConfigFile -Encoding UTF8
+            Set-CodexNotifyConfig -Path $script:CodexConfigFile -NotifyLine $notifyLine
             Write-Success "Codex notifications enabled!"
             Write-Info "Config: $script:CodexConfigFile"
             Send-Notification -Title "Code-Notify" -Message "Codex notifications enabled!" -Type "success"

--- a/tests/test-config-preservation.sh
+++ b/tests/test-config-preservation.sh
@@ -465,6 +465,130 @@ run_test_project_hooks_special_chars() {
     return $?
 }
 
+run_test_codex_toml_placement() {
+    local test_dir=$(mktemp -d)
+    trap "rm -rf $test_dir" RETURN
+
+    export HOME="$test_dir"
+    export CODEX_HOME="$test_dir/.codex"
+    mkdir -p "$CODEX_HOME"
+
+    (
+        source "$SCRIPT_DIR/../lib/code-notify/core/config.sh"
+
+        echo ""
+        echo "=== Testing Codex TOML placement ==="
+
+        cat > "$CODEX_CONFIG_FILE" << 'EOF'
+[notice.model_migrations]
+"gpt-5.1-codex-max" = "gpt-5.2-codex"
+
+[mcp_servers.playwright]
+args = ["@playwright/mcp@latest"]
+command = "npx"
+
+[features]
+multi_agent = true
+EOF
+
+        if ! enable_codex_hooks; then
+            echo "❌ Failed to enable Codex hooks"
+            exit 1
+        fi
+
+        local notify_line
+        local first_table_line
+        notify_line=$(grep -nE '^notify\s*=' "$CODEX_CONFIG_FILE" | head -n1 | cut -d: -f1)
+        first_table_line=$(grep -nE '^\s*\[' "$CODEX_CONFIG_FILE" | head -n1 | cut -d: -f1)
+
+        if [[ -z "$notify_line" || -z "$first_table_line" || "$notify_line" -ge "$first_table_line" ]]; then
+            echo "❌ notify was not inserted before the first TOML table"
+            cat "$CODEX_CONFIG_FILE"
+            exit 1
+        fi
+        echo "✅ notify inserted before the first TOML table"
+
+        if ! is_codex_enabled; then
+            echo "❌ is_codex_enabled did not detect the repaired config"
+            exit 1
+        fi
+        echo "✅ is_codex_enabled only accepts top-level notify"
+
+        if command -v python3 &> /dev/null; then
+            if ! python3 - "$CODEX_CONFIG_FILE" << 'PY'
+import sys, tomllib
+
+with open(sys.argv[1], "rb") as fh:
+    data = tomllib.load(fh)
+
+assert "notify" in data, data
+assert "notify" not in data.get("features", {}), data
+PY
+            then
+                echo "❌ TOML parser still sees notify under a table"
+                cat "$CODEX_CONFIG_FILE"
+                exit 1
+            fi
+            echo "✅ TOML parser sees notify at top-level"
+        fi
+
+        if ! disable_codex_hooks; then
+            echo "❌ Failed to disable Codex hooks"
+            exit 1
+        fi
+
+        if grep -qE '^notify\s*=' "$CODEX_CONFIG_FILE" || grep -q '^# Code-Notify: Desktop notifications' "$CODEX_CONFIG_FILE"; then
+            echo "❌ disable_codex_hooks did not remove Code-Notify lines"
+            cat "$CODEX_CONFIG_FILE"
+            exit 1
+        fi
+
+        if ! grep -q '^\[features\]' "$CODEX_CONFIG_FILE" || ! grep -q '^multi_agent = true' "$CODEX_CONFIG_FILE"; then
+            echo "❌ disable_codex_hooks did not preserve existing TOML content"
+            cat "$CODEX_CONFIG_FILE"
+            exit 1
+        fi
+        echo "✅ disable_codex_hooks preserves existing TOML content"
+
+        cat > "$CODEX_CONFIG_FILE" << 'EOF'
+[features]
+multi_agent = true
+
+# Code-Notify: Desktop notifications
+notify = ["bash", "-c", "/tmp/notifier stop codex"]
+EOF
+
+        if is_codex_enabled; then
+            echo "❌ Misplaced notify should not count as enabled"
+            exit 1
+        fi
+        echo "✅ Misplaced notify is not treated as enabled"
+
+        if ! enable_codex_hooks; then
+            echo "❌ Failed to repair misplaced notify"
+            exit 1
+        fi
+
+        notify_line=$(grep -nE '^notify\s*=' "$CODEX_CONFIG_FILE" | head -n1 | cut -d: -f1)
+        first_table_line=$(grep -nE '^\s*\[' "$CODEX_CONFIG_FILE" | head -n1 | cut -d: -f1)
+
+        if [[ -z "$notify_line" || -z "$first_table_line" || "$notify_line" -ge "$first_table_line" ]]; then
+            echo "❌ Re-enable did not move notify back to top-level"
+            cat "$CODEX_CONFIG_FILE"
+            exit 1
+        fi
+
+        if [[ $(grep -cE '^notify\s*=' "$CODEX_CONFIG_FILE") -ne 1 ]]; then
+            echo "❌ Re-enable left duplicate notify entries"
+            cat "$CODEX_CONFIG_FILE"
+            exit 1
+        fi
+        echo "✅ Re-enable repairs misplaced notify without duplicates"
+    )
+
+    return $?
+}
+
 echo "============================================"
 echo "Config Preservation Bug Fix Tests"
 echo "============================================"
@@ -516,6 +640,9 @@ for test_case in "space" "semicolon" "quote"; do
         run_test_project_hooks_special_chars "python" "$test_case" || fail "Python project hooks $test_case tests failed"
     fi
 done
+
+# Test 8: Codex TOML placement and repair
+run_test_codex_toml_placement || fail "Codex TOML placement test failed"
 
 echo ""
 echo "============================================"


### PR DESCRIPTION
## Summary
- insert the Codex `notify` key before the first TOML table instead of appending at EOF
- treat Codex as enabled only when `notify` exists at TOML top-level
- add regression coverage for the issue sample config and misplaced-notify repair

## Testing
- `bash -n lib/code-notify/core/config.sh`
- `bash -n tests/test-config-preservation.sh`
- `./tests/test-config-preservation.sh`
- manual `./bin/code-notify on codex` against the issue sample `config.toml`

Closes #32