### PR TITLE
Fix Windows version shortcut and add explicit all aliases

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -159,7 +159,7 @@ jobs:
         UPDATE_OUTPUT="$(CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" cn update check)"
         echo "$UPDATE_OUTPUT"
 
-        if ! echo "$UPDATE_OUTPUT" | grep -q 'Already up to date'; then
+        if ! echo "$UPDATE_OUTPUT" | grep -q 'Code-Notify is up to date'; then
           echo "ERROR: update check did not report the install as current"
           exit 1
         fi
@@ -176,7 +176,7 @@ jobs:
         UPDATE_OUTPUT="$(CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" cn update)"
         echo "$UPDATE_OUTPUT"
 
-        if ! echo "$UPDATE_OUTPUT" | grep -q 'Already up to date'; then
+        if ! echo "$UPDATE_OUTPUT" | grep -q 'Code-Notify is up to date'; then
           echo "ERROR: update command did not skip reinstalling the current version"
           exit 1
         fi
@@ -190,7 +190,7 @@ jobs:
         export PATH="$HOME/.local/bin:$PATH"
 
         # Enable
-        cn on
+        cn on all
 
         # Check settings.json was created with hooks
         SETTINGS_FILE="$HOME/.claude/settings.json"
@@ -206,7 +206,7 @@ jobs:
         echo "OK: Notifications enabled, hooks configured"
 
         # Disable
-        cn off
+        cn off all
 
         if jq -e '.hooks' "$SETTINGS_FILE" > /dev/null 2>&1; then
           echo "ERROR: hooks not removed from settings"

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -113,6 +113,21 @@ jobs:
       run: |
         & "$env:USERPROFILE\.code-notify\bin\cn.ps1" version
 
+    - name: Test CLI commands (version shortcut)
+      run: |
+        $versionOutput = & "$env:USERPROFILE\.code-notify\bin\cn.ps1" -v | Out-String
+        Write-Host $versionOutput
+
+        if ($versionOutput -match 'VERBOSE:') {
+          Write-Host "ERROR: cn -v leaked PowerShell verbose import output" -ForegroundColor Red
+          exit 1
+        }
+
+        if ($versionOutput -notmatch 'code-notify version') {
+          Write-Host "ERROR: cn -v did not resolve to the version command" -ForegroundColor Red
+          exit 1
+        }
+
     - name: Test CLI commands (status)
       run: |
         & "$env:USERPROFILE\.code-notify\bin\cn.ps1" status
@@ -124,7 +139,7 @@ jobs:
         $updateOutput = & "$env:USERPROFILE\.code-notify\bin\cn.ps1" update check | Out-String
         Write-Host $updateOutput
 
-        if ($updateOutput -notmatch 'Already up to date') {
+        if ($updateOutput -notmatch 'Code-Notify is up to date') {
           Write-Host "ERROR: update check did not report the install as current" -ForegroundColor Red
           exit 1
         }
@@ -141,7 +156,7 @@ jobs:
         $updateOutput = & "$env:USERPROFILE\.code-notify\bin\cn.ps1" update | Out-String
         Write-Host $updateOutput
 
-        if ($updateOutput -notmatch 'Already up to date') {
+        if ($updateOutput -notmatch 'Code-Notify is up to date') {
           Write-Host "ERROR: update command did not skip reinstalling the current version" -ForegroundColor Red
           exit 1
         }
@@ -166,7 +181,7 @@ jobs:
     - name: Test enable/disable notifications
       run: |
         # Enable
-        & "$env:USERPROFILE\.code-notify\bin\cn.ps1" on
+        & "$env:USERPROFILE\.code-notify\bin\cn.ps1" on all
 
         # Check settings.json was created with hooks
         $settingsFile = "$env:USERPROFILE\.claude\settings.json"
@@ -183,7 +198,7 @@ jobs:
         Write-Host "OK: Notifications enabled, hooks configured" -ForegroundColor Green
 
         # Disable
-        & "$env:USERPROFILE\.code-notify\bin\cn.ps1" off
+        & "$env:USERPROFILE\.code-notify\bin\cn.ps1" off all
 
         $settings = Get-Content $settingsFile -Raw | ConvertFrom-Json
         if ($settings.hooks) {

--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ curl -s https://raw.githubusercontent.com/mylee04/code-notify/main/docs/installa
 | Command              | Description                                  |
 | -------------------- | -------------------------------------------- |
 | `cn on`              | Enable notifications for all detected tools  |
+| `cn on all`          | Explicit alias for enabling all detected tools |
 | `cn on claude`       | Enable for Claude Code only                  |
 | `cn on codex`        | Enable for Codex only                        |
 | `cn on gemini`       | Enable for Gemini CLI only                   |
 | `cn off`             | Disable notifications                        |
+| `cn off all`         | Explicit alias for disabling all tools       |
 | `cn test`            | Send test notification                       |
 | `cn status`          | Show current status                          |
 | `cn update`          | Update code-notify                           |
@@ -108,6 +110,7 @@ curl -s https://raw.githubusercontent.com/mylee04/code-notify/main/docs/installa
 | `cnp on`             | Enable for current project only              |
 
 When enabling project notifications with `cnp on`, Code-Notify warns if Claude project trust does not appear to be accepted yet.
+`all` is also accepted as an explicit alias for global commands such as `cn on all`, `cn off all`, and `cn status all`.
 
 ## How It Works
 

--- a/lib/code-notify/commands/global.sh
+++ b/lib/code-notify/commands/global.sh
@@ -151,18 +151,31 @@ print_update_status() {
     local latest_version="$2"
     local comparison="$3"
 
-    info "Current version: $current_version"
-    info "Latest release: $latest_version"
-
     case "$comparison" in
         -1)
+            info "Current version: $current_version"
             warning "Update available: $current_version -> $latest_version"
             ;;
         0)
-            success "Already up to date"
+            info "Current version: $current_version"
+            success "Code-Notify is up to date ($current_version)"
             ;;
         1)
-            info "Installed version is newer than the latest release"
+            info "Current version: $current_version"
+            info "Installed version is newer than the latest release ($latest_version)"
+            ;;
+    esac
+}
+
+normalize_tool_argument() {
+    local tool="${1:-}"
+
+    case "$tool" in
+        ""|"all")
+            printf '%s\n' ""
+            ;;
+        *)
+            printf '%s\n' "$tool"
             ;;
     esac
 }
@@ -309,7 +322,8 @@ show_version() {
 
 # Enable notifications globally
 enable_notifications_global() {
-    local tool="${1:-}"
+    local tool
+    tool="$(normalize_tool_argument "${1:-}")"
 
     header "${ROCKET} Enabling Notifications"
     echo ""
@@ -400,7 +414,8 @@ enable_single_tool() {
 
 # Disable notifications globally
 disable_notifications_global() {
-    local tool="${1:-}"
+    local tool
+    tool="$(normalize_tool_argument "${1:-}")"
 
     header "${MUTE} Disabling Notifications"
     echo ""
@@ -462,6 +477,16 @@ disable_single_tool() {
 
 # Show current status
 show_status() {
+    local arg
+    local check_updates_flag=""
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--check-updates" ]]; then
+            check_updates_flag="yes"
+            break
+        fi
+    done
+
     header "${INFO} Code-Notify Status"
     echo ""
 
@@ -576,7 +601,7 @@ show_status() {
     dim "code-notify version $VERSION"
 
     # Check for updates if --check-updates flag is passed
-    if [[ "$1" == "--check-updates" ]]; then
+    if [[ -n "$check_updates_flag" ]]; then
         check_for_updates
     fi
 }

--- a/lib/code-notify/utils/help.sh
+++ b/lib/code-notify/utils/help.sh
@@ -17,10 +17,13 @@ ${BOLD}USAGE:${RESET}
 
 ${BOLD}COMMANDS:${RESET}
     ${GREEN}on${RESET}              Enable notifications (all detected tools)
+    ${GREEN}on${RESET} all          Enable notifications (explicit alias for all detected tools)
     ${GREEN}on${RESET} <tool>       Enable for specific tool (claude/codex/gemini)
     ${GREEN}off${RESET}             Disable notifications (all tools)
+    ${GREEN}off${RESET} all         Disable notifications (explicit alias for all tools)
     ${GREEN}off${RESET} <tool>      Disable for specific tool
     ${GREEN}status${RESET}          Show status for all tools
+    ${GREEN}status${RESET} all      Show status for all tools (explicit alias)
     ${GREEN}test${RESET}            Send a test notification
     ${GREEN}update${RESET} [check]  Update code-notify or check the latest release
     ${GREEN}alerts${RESET} <cmd>    Configure which events trigger alerts
@@ -69,9 +72,12 @@ ${BOLD}ALIASES:${RESET}
 
 ${BOLD}EXAMPLES:${RESET}
     cn on                   # Enable for all detected tools
+    cn on all               # Same as cn on
     cn on claude            # Enable for Claude Code only
     cn off                  # Disable all
+    cn off all              # Same as cn off
     cn status               # Show status for all tools
+    cn status all           # Same as cn status
     cn test                 # Send test notification
     cn update check         # Check whether an update is needed and show the update command
     cn alerts               # Show alert type config

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1071,19 +1071,25 @@ function Write-UpdateStatus {
         [pscustomobject]$Status
     )
 
-    Write-Output "[i] Current version: $($Status.CurrentVersion)"
-
     if (-not $Status.LatestVersion) {
+        Write-Output "[i] Current version: $($Status.CurrentVersion)"
         Write-Output "[!] Could not determine the latest release"
         return
     }
 
-    Write-Output "[i] Latest release: $($Status.LatestVersion)"
-
     switch ($Status.Comparison) {
-        -1 { Write-Output "[!] Update available: $($Status.CurrentVersion) -> $($Status.LatestVersion)" }
-        0 { Write-Output "[OK] Already up to date" }
-        1 { Write-Output "[i] Installed version is newer than the latest release" }
+        -1 {
+            Write-Output "[i] Current version: $($Status.CurrentVersion)"
+            Write-Output "[!] Update available: $($Status.CurrentVersion) -> $($Status.LatestVersion)"
+        }
+        0 {
+            Write-Output "[i] Current version: $($Status.CurrentVersion)"
+            Write-Output "[OK] Code-Notify is up to date ($($Status.CurrentVersion))"
+        }
+        1 {
+            Write-Output "[i] Current version: $($Status.CurrentVersion)"
+            Write-Output "[i] Installed version is newer than the latest release ($($Status.LatestVersion))"
+        }
     }
 }
 
@@ -1157,9 +1163,9 @@ USAGE:
     cnp <command>             # Project command alias
 
 COMMANDS:
-    on [tool]       Enable notifications globally or for a specific tool
-    off [tool]      Disable notifications globally or for a specific tool
-    status [tool]   Show notification status
+    on [tool|all]   Enable notifications globally or for a specific tool
+    off [tool|all]  Disable notifications globally or for a specific tool
+    status [tool|all] Show notification status
     test            Send a test notification
     update [check]  Update code-notify or check the latest release
     voice on        Enable voice notifications
@@ -1189,7 +1195,9 @@ PROJECT COMMANDS:
 
 EXAMPLES:
     code-notify on            # Enable Claude notifications
+    cn on all                 # Enable all detected tools
     cn on codex               # Enable Codex notifications
+    cn off all                # Disable all tools
     cn off gemini             # Disable Gemini notifications
     cnp on                    # Enable Claude project notifications
     cn test                   # Send test notification
@@ -1678,8 +1686,21 @@ exit 0
     $cliWrapper = @'
 # Code-Notify CLI wrapper
 param([Parameter(ValueFromRemainingArguments)][string[]]$Args)
-Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force
-Invoke-CodeNotify @Args
+$requestedVersionShortcut = $false
+$invocationLine = [string]$MyInvocation.Line
+if ($Args.Count -eq 1 -and @('version', '-v', '--version') -contains $Args[0]) {
+    $requestedVersionShortcut = $true
+} elseif ($Args.Count -eq 0 -and $invocationLine -match '(^|\s)-v($|\s)') {
+    $requestedVersionShortcut = $true
+} elseif ($Args.Count -eq 0 -and $invocationLine -match '(^|\s)--version($|\s)') {
+    $requestedVersionShortcut = $true
+}
+Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force -Verbose:$false
+if ($requestedVersionShortcut) {
+    Invoke-CodeNotify "version"
+} else {
+    Invoke-CodeNotify @Args
+}
 '@
 
     $cliWrapper | Set-Content "$InstallDir\bin\code-notify.ps1" -Encoding UTF8
@@ -1688,8 +1709,21 @@ Invoke-CodeNotify @Args
     $cnWrapper = @'
 # cn - Code-Notify shortcut
 param([Parameter(ValueFromRemainingArguments)][string[]]$Args)
-Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force
-Invoke-CodeNotify @Args
+$requestedVersionShortcut = $false
+$invocationLine = [string]$MyInvocation.Line
+if ($Args.Count -eq 1 -and @('version', '-v', '--version') -contains $Args[0]) {
+    $requestedVersionShortcut = $true
+} elseif ($Args.Count -eq 0 -and $invocationLine -match '(^|\s)-v($|\s)') {
+    $requestedVersionShortcut = $true
+} elseif ($Args.Count -eq 0 -and $invocationLine -match '(^|\s)--version($|\s)') {
+    $requestedVersionShortcut = $true
+}
+Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force -Verbose:$false
+if ($requestedVersionShortcut) {
+    Invoke-CodeNotify "version"
+} else {
+    Invoke-CodeNotify @Args
+}
 '@
     $cnWrapper | Set-Content "$InstallDir\bin\cn.ps1" -Encoding UTF8
 
@@ -1697,7 +1731,7 @@ Invoke-CodeNotify @Args
     $cnpWrapper = @'
 # cnp - Code-Notify Project shortcut
 param([Parameter(ValueFromRemainingArguments)][string[]]$Args)
-Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force
+Import-Module "$env:USERPROFILE\.code-notify\lib\CodeNotify.psm1" -Force -Verbose:$false
 Invoke-CodeNotify "project" @Args
 '@
     $cnpWrapper | Set-Content "$InstallDir\bin\cnp.ps1" -Encoding UTF8

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -104,7 +104,7 @@ fi
 
 # Test 8: update check command works
 test_start "update check command"
-if CODE_NOTIFY_INSTALL_METHOD=script CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" ./bin/code-notify update check 2>&1 | grep -q "Already up to date"; then
+if CODE_NOTIFY_INSTALL_METHOD=script CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" ./bin/code-notify update check 2>&1 | grep -q "Code-Notify is up to date"; then
     test_pass
 else
     test_fail "update check command failed"
@@ -112,7 +112,7 @@ fi
 
 # Test 9: update command skips reinstalling current versions
 test_start "no-op update command"
-if CODE_NOTIFY_INSTALL_METHOD=script CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" ./bin/code-notify update 2>&1 | grep -q "Already up to date"; then
+if CODE_NOTIFY_INSTALL_METHOD=script CODE_NOTIFY_LATEST_VERSION="$CURRENT_VERSION" ./bin/code-notify update 2>&1 | grep -q "Code-Notify is up to date"; then
     test_pass
 else
     test_fail "update command did not skip reinstalling the current version"
@@ -124,6 +124,14 @@ if bash tests/test-project-trust-warning.sh >/dev/null 2>&1; then
     test_pass
 else
     test_fail "project trust warning behavior failed"
+fi
+
+# Test 11: explicit all aliases map to global behavior
+test_start "all tool aliases"
+if bash tests/test-all-alias.sh >/dev/null 2>&1; then
+    test_pass
+else
+    test_fail "all aliases failed"
 fi
 
 # Summary

--- a/tests/test-all-alias.sh
+++ b/tests/test-all-alias.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+pass() { echo "PASS: $1"; }
+fail() { echo "FAIL: $1"; exit 1; }
+
+run_enable_all_alias_test() {
+    local test_dir
+    test_dir="$(mktemp -d)"
+
+    (
+        export HOME="$test_dir"
+        export CLAUDE_HOME="$HOME/.claude"
+        mkdir -p "$CLAUDE_HOME/notifications"
+
+        source "$SCRIPT_DIR/../lib/code-notify/utils/colors.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/detect.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/help.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/core/config.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/commands/global.sh"
+
+        get_installed_tools() { echo "claude codex gemini"; }
+        is_tool_installed() { return 0; }
+        is_tool_enabled() { return 1; }
+        enable_tool() {
+            echo "$1" >> "$HOME/enabled-tools"
+            return 0
+        }
+        test_notification() { return 0; }
+
+        enable_notifications_global all >/dev/null 2>&1 || fail "cn on all alias did not enable notifications"
+
+        local enabled_tools
+        enabled_tools="$(sort "$HOME/enabled-tools" | tr '\n' ' ')"
+        [[ "$enabled_tools" == "claude codex gemini " ]] || fail "cn on all did not enable every detected tool"
+    )
+
+    rm -rf "$test_dir"
+}
+
+run_disable_all_alias_test() {
+    local test_dir
+    test_dir="$(mktemp -d)"
+
+    (
+        export HOME="$test_dir"
+        export CLAUDE_HOME="$HOME/.claude"
+        mkdir -p "$CLAUDE_HOME/notifications"
+
+        source "$SCRIPT_DIR/../lib/code-notify/utils/colors.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/detect.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/help.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/core/config.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/commands/global.sh"
+
+        is_tool_enabled() { return 0; }
+        disable_tool() {
+            echo "$1" >> "$HOME/disabled-tools"
+            return 0
+        }
+
+        disable_notifications_global all >/dev/null 2>&1 || fail "cn off all alias did not disable notifications"
+
+        local disabled_tools
+        disabled_tools="$(sort "$HOME/disabled-tools" | tr '\n' ' ')"
+        [[ "$disabled_tools" == "claude codex gemini " ]] || fail "cn off all did not disable every enabled tool"
+    )
+
+    rm -rf "$test_dir"
+}
+
+run_status_all_alias_test() {
+    local test_dir
+    test_dir="$(mktemp -d)"
+
+    (
+        export HOME="$test_dir"
+        export CLAUDE_HOME="$HOME/.claude"
+        mkdir -p "$CLAUDE_HOME/notifications"
+
+        source "$SCRIPT_DIR/../lib/code-notify/utils/colors.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/detect.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/utils/help.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/core/config.sh"
+        source "$SCRIPT_DIR/../lib/code-notify/commands/global.sh"
+
+        is_tool_installed() { return 1; }
+        is_tool_enabled() { return 1; }
+        is_voice_enabled() { return 1; }
+        is_sound_enabled() { return 1; }
+        get_notify_types() { echo "idle_prompt"; }
+        detect_os() { echo "linux"; }
+
+        show_status all >/dev/null 2>&1 || fail "cn status all alias did not behave like cn status"
+    )
+
+    rm -rf "$test_dir"
+}
+
+run_enable_all_alias_test
+pass "cn on all enables all detected tools"
+
+run_disable_all_alias_test
+pass "cn off all disables all tools"
+
+run_status_all_alias_test
+pass "cn status all behaves like the global status command"

--- a/tests/test-update-command.sh
+++ b/tests/test-update-command.sh
@@ -50,7 +50,7 @@ latest_override=$(CODE_NOTIFY_LATEST_VERSION="v9.9.9" get_latest_release_version
 pass "normalizes the latest release version override"
 
 script_check_output=$(CODE_NOTIFY_INSTALL_METHOD="script" CODE_NOTIFY_LATEST_VERSION="$VERSION" "$SCRIPT_DIR/../bin/code-notify" update check 2>&1)
-echo "$script_check_output" | grep -q "Already up to date" || fail "expected script update check to report an up-to-date install"
+echo "$script_check_output" | grep -q "Code-Notify is up to date" || fail "expected script update check to report an up-to-date install"
 echo "$script_check_output" | grep -q "scripts/install.sh" || fail "expected script update check to show the install script command"
 pass "update check reports when script installs are already current"
 
@@ -59,7 +59,7 @@ echo "$outdated_check_output" | grep -q "Update available: $VERSION -> 9.9.9" ||
 pass "update check reports when script installs are behind the latest release"
 
 noop_update_output=$(CODE_NOTIFY_INSTALL_METHOD="script" CODE_NOTIFY_LATEST_VERSION="$VERSION" "$SCRIPT_DIR/../bin/code-notify" update 2>&1)
-echo "$noop_update_output" | grep -q "Already up to date" || fail "expected update command to skip reinstalling the current version"
+echo "$noop_update_output" | grep -q "Code-Notify is up to date" || fail "expected update command to skip reinstalling the current version"
 if echo "$noop_update_output" | grep -q "Update complete!"; then
     fail "expected update command to skip the reinstall path when already current"
 fi


### PR DESCRIPTION
## Summary
- fix `cn -v` on Windows so it resolves to the version command without leaking PowerShell verbose import output
- simplify the up-to-date update output and keep the current version visible
- accept `all` as an explicit alias for global `on`, `off`, and `status` commands

## Testing
- bash tests/test-update-command.sh
- bash tests/test-all-alias.sh
- ./scripts/run_tests.sh