### PR TITLE
fix: download click-through utils in install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,6 +124,10 @@ else
     curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/help.sh" -o "$INSTALL_DIR/lib/code-notify/utils/help.sh"
     curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/voice.sh" -o "$INSTALL_DIR/lib/code-notify/utils/voice.sh"
     curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/sound.sh" -o "$INSTALL_DIR/lib/code-notify/utils/sound.sh"
+    curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/click-through.sh" -o "$INSTALL_DIR/lib/code-notify/utils/click-through.sh"
+    curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/click-through-store.sh" -o "$INSTALL_DIR/lib/code-notify/utils/click-through-store.sh"
+    curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/click-through-runtime.sh" -o "$INSTALL_DIR/lib/code-notify/utils/click-through-runtime.sh"
+    curl -fsSL "$GITHUB_RAW/lib/code-notify/utils/click-through-resolver.sh" -o "$INSTALL_DIR/lib/code-notify/utils/click-through-resolver.sh"
 fi
 
 # Update paths in the main script


### PR DESCRIPTION
- Add missing click-through.sh, click-through-store.sh, click-through-runtime.sh, click-through-resolver.sh downloads
- These files are sourced by notifier.sh but were not fetched, causing installation failures on Linux and macOS