### PR TITLE
feat: add ask_user alert type for immediate AskUserQuestion notification

### DIFF
--- a/lib/code-notify/commands/global.sh
+++ b/lib/code-notify/commands/global.sh
@@ -996,6 +996,12 @@ show_alerts_status() {
         echo "    ${MUTE} ${DIM}elicitation_dialog${RESET}"
     fi
 
+    if is_notify_type_enabled "ask_user"; then
+        echo "    ${CHECK_MARK} ${GREEN}ask_user${RESET} - AI asks a question (immediate notification)"
+    else
+        echo "    ${MUTE} ${DIM}ask_user${RESET}"
+    fi
+
     echo ""
     echo "  Claude agent/team hook events:"
     if is_notify_type_enabled "SubagentStart"; then
@@ -1050,6 +1056,7 @@ show_available_alert_types() {
     echo "  ${CYAN}permission_prompt${RESET}  - AI needs tool permission (can be noisy)"
     echo "  ${CYAN}auth_success${RESET}       - Authentication success"
     echo "  ${CYAN}elicitation_dialog${RESET} - MCP tool input needed"
+    echo "  ${CYAN}ask_user${RESET}           - AI asks a question (immediate PreToolUse notification)"
     echo ""
     echo "Claude agent/team hook events:"
     echo "  ${CYAN}SubagentStart${RESET}      - A Claude subagent started"
@@ -1079,9 +1086,17 @@ add_alert_type() {
     fi
 
     add_notify_type "$type"
+
+    # For ask_user: register PreToolUse hook immediately
+    if [[ "$type" == "ask_user" ]] && is_tool_enabled "claude"; then
+        register_ask_user_hook "$GLOBAL_SETTINGS_FILE" "$(get_global_claude_pre_tool_use_command)"
+    fi
+
     success "Added: $type"
-    echo ""
-    info "Run ${CYAN}cn on${RESET} to apply changes"
+    if [[ "$type" != "ask_user" ]]; then
+        echo ""
+        info "Run ${CYAN}cn on${RESET} to apply changes"
+    fi
 }
 
 # Remove an alert type
@@ -1102,9 +1117,17 @@ remove_alert_type() {
     fi
 
     remove_notify_type "$type"
+
+    # For ask_user: unregister PreToolUse hook immediately
+    if [[ "$type" == "ask_user" ]] && is_tool_enabled "claude"; then
+        unregister_ask_user_hook "$GLOBAL_SETTINGS_FILE"
+    fi
+
     success "Removed: $type"
-    echo ""
-    info "Run ${CYAN}cn on${RESET} to apply changes"
+    if [[ "$type" != "ask_user" ]]; then
+        echo ""
+        info "Run ${CYAN}cn on${RESET} to apply changes"
+    fi
 }
 
 # Reset alert types to default

--- a/lib/code-notify/core/config.sh
+++ b/lib/code-notify/core/config.sh
@@ -41,6 +41,7 @@ CLAUDE_EVENT_ALERT_TYPES="SubagentStart|SubagentStop|TeammateIdle|TaskCreated|Ta
 # - permission_prompt: AI needs permission to use a tool
 # - auth_success: Authentication success notifications
 # - elicitation_dialog: MCP tool input needed
+# - ask_user: AI is asking a question via AskUserQuestion (immediate PreToolUse notification)
 # - SubagentStart/SubagentStop: Claude Code subagent lifecycle events
 # - TeammateIdle: Claude Code teammate waiting for input
 # - TaskCreated/TaskCompleted: Claude Code agent-team task lifecycle events
@@ -269,6 +270,15 @@ get_project_claude_notify_command() {
 get_project_claude_stop_command() {
     local project_name="$1"
     printf '%s stop claude %s\n' "$(shell_quote "$(get_notify_script)")" "$(shell_quote "$project_name")"
+}
+
+get_global_claude_pre_tool_use_command() {
+    printf '%s PreToolUse claude\n' "$(get_notify_script)"
+}
+
+get_project_claude_pre_tool_use_command() {
+    local project_name="$1"
+    printf '%s PreToolUse claude %s\n' "$(shell_quote "$(get_notify_script)")" "$(shell_quote "$project_name")"
 }
 
 get_managed_claude_event_pattern() {
@@ -917,6 +927,188 @@ PYTHON
     fi
 }
 
+# ============================================
+# PreToolUse Hook for AskUserQuestion
+# ============================================
+
+# Register PreToolUse hook for AskUserQuestion when ask_user alert type is enabled
+register_ask_user_hook() {
+    local file="$1"
+    local pre_tool_cmd="$2"
+
+    if ! is_notify_type_enabled "ask_user"; then
+        return 0
+    fi
+
+    if has_jq; then
+        local settings="{}"
+        if [[ -f "$file" ]]; then
+            settings=$(cat "$file")
+        fi
+
+        local new_settings
+        new_settings=$(printf '%s\n' "$settings" | jq --arg cmd "$pre_tool_cmd" '
+            def array_or_empty:
+                if type == "array" then . else [] end;
+            .hooks = (if (.hooks | type) == "object" then .hooks else {} end) |
+            .hooks.PreToolUse = (
+                (.hooks.PreToolUse | array_or_empty | map(select(.matcher != "AskUserQuestion"))) + [{
+                    "matcher": "AskUserQuestion",
+                    "hooks": [{
+                        "type": "command",
+                        "command": $cmd
+                    }]
+                }]
+            )
+        ' 2>/dev/null)
+
+        if [[ -n "$new_settings" ]]; then
+            atomic_write "$file" "$new_settings"
+        fi
+    elif has_python3; then
+        local settings="{}"
+        if [[ -f "$file" ]]; then
+            settings=$(cat "$file")
+        fi
+
+        local tmp_json
+        tmp_json=$(mktemp) || return 1
+        printf '%s\n' "$settings" > "$tmp_json"
+
+        python3 - "$file" "$pre_tool_cmd" "$tmp_json" << 'PYTHON'
+import json, os, sys, tempfile
+
+file_path, pre_tool_cmd, json_file = sys.argv[1:4]
+
+try:
+    with open(json_file, "r") as fh:
+        settings = json.load(fh)
+finally:
+    try:
+        os.unlink(json_file)
+    except OSError:
+        pass
+
+hooks = settings.get("hooks")
+if not isinstance(hooks, dict):
+    hooks = {}
+else:
+    hooks = dict(hooks)
+
+pre_tool_entries = [e for e in hooks.get("PreToolUse", []) if e.get("matcher") != "AskUserQuestion"]
+pre_tool_entries.append({
+    "matcher": "AskUserQuestion",
+    "hooks": [{"type": "command", "command": pre_tool_cmd}]
+})
+hooks["PreToolUse"] = pre_tool_entries
+settings["hooks"] = hooks
+
+dir_path = os.path.dirname(file_path)
+content = json.dumps(settings, indent=2)
+fd, tmp_path = tempfile.mkstemp(dir=dir_path, prefix=".tmp.")
+try:
+    with os.fdopen(fd, "w") as fh:
+        fh.write(content)
+        fh.write("\n")
+    os.replace(tmp_path, file_path)
+except Exception:
+    os.unlink(tmp_path)
+    raise
+PYTHON
+        return $?
+    else
+        echo "Error: jq or python3 required for config preservation" >&2
+        echo "Install jq: brew install jq" >&2
+        return 1
+    fi
+}
+
+# Unregister PreToolUse hook for AskUserQuestion
+unregister_ask_user_hook() {
+    local file="$1"
+
+    if [[ ! -f "$file" ]]; then
+        return 0
+    fi
+
+    if has_jq; then
+        local settings
+        settings=$(cat "$file")
+
+        local new_settings
+        new_settings=$(printf '%s\n' "$settings" | jq '
+            def array_or_empty:
+                if type == "array" then . else [] end;
+            if (.hooks // {}).PreToolUse then
+                .hooks.PreToolUse = (
+                    (.hooks.PreToolUse | array_or_empty) | map(
+                        select(.matcher != "AskUserQuestion")
+                    )
+                ) |
+                if (.hooks.PreToolUse | length) == 0 then del(.hooks.PreToolUse) else . end |
+                if (.hooks | length) == 0 then del(.hooks) else . end
+            else . end
+        ' 2>/dev/null)
+
+        if [[ -n "$new_settings" ]]; then
+            atomic_write "$file" "$new_settings"
+        fi
+    elif has_python3; then
+        local tmp_json
+        tmp_json=$(mktemp) || return 1
+        cat "$file" > "$tmp_json"
+
+        python3 - "$file" "$tmp_json" << 'PYTHON'
+import json, os, sys, tempfile
+
+file_path, json_file = sys.argv[1:3]
+
+try:
+    with open(json_file, "r") as fh:
+        settings = json.load(fh)
+finally:
+    try:
+        os.unlink(json_file)
+    except OSError:
+        pass
+
+hooks = settings.get("hooks", {})
+pre_tool = hooks.get("PreToolUse", [])
+hooks["PreToolUse"] = [e for e in pre_tool if e.get("matcher") != "AskUserQuestion"]
+if not hooks["PreToolUse"]:
+    del hooks["PreToolUse"]
+if hooks:
+    settings["hooks"] = hooks
+else:
+    settings.pop("hooks", None)
+
+if not settings:
+    try:
+        os.remove(file_path)
+    except FileNotFoundError:
+        pass
+    raise SystemExit(0)
+
+dir_path = os.path.dirname(file_path)
+content = json.dumps(settings, indent=2)
+fd, tmp_path = tempfile.mkstemp(dir=dir_path, prefix=".tmp.")
+try:
+    with os.fdopen(fd, "w") as fh:
+        fh.write(content)
+        fh.write("\n")
+    os.replace(tmp_path, file_path)
+except Exception:
+    os.unlink(tmp_path)
+    raise
+PYTHON
+        return $?
+    else
+        echo "Error: jq or python3 required for config preservation" >&2
+        echo "Install jq: brew install jq" >&2
+        return 1
+    fi
+}
+
 enable_hooks_in_settings() {
     local notify_matcher
     notify_matcher=$(get_notify_matcher)
@@ -929,6 +1121,9 @@ enable_hooks_in_settings() {
         "enable" \
         "$(get_notify_script) " \
         " claude"
+
+    # Register PreToolUse hook for AskUserQuestion if ask_user alert type is enabled
+    register_ask_user_hook "$GLOBAL_SETTINGS_FILE" "$(get_global_claude_pre_tool_use_command)"
 }
 
 # Disable hooks in settings.json (new format)
@@ -945,6 +1140,9 @@ disable_hooks_in_settings() {
         "disable" \
         "$(get_notify_script) " \
         " claude"
+
+    # Remove PreToolUse hook for AskUserQuestion
+    unregister_ask_user_hook "$GLOBAL_SETTINGS_FILE"
 }
 
 # Disable hooks in project settings.json
@@ -965,6 +1163,9 @@ disable_project_hooks_in_settings() {
         "disable" \
         "$(shell_quote "$(get_notify_script)") " \
         " claude $(shell_quote "$project_name")"
+
+    # Remove PreToolUse hook for AskUserQuestion
+    unregister_ask_user_hook "$project_settings"
 }
 
 # Enable hooks in project settings.json
@@ -985,6 +1186,9 @@ enable_project_hooks_in_settings() {
         "enable" \
         "$(shell_quote "$(get_notify_script)") " \
         " claude $(shell_quote "$project_name")"
+
+    # Register PreToolUse hook for AskUserQuestion if ask_user alert type is enabled
+    register_ask_user_hook "$project_settings" "$(get_project_claude_pre_tool_use_command "$project_name")"
 }
 
 # Check if project has settings.json with code-notify hooks
@@ -1333,7 +1537,7 @@ normalize_alert_type() {
     key="$(printf '%s' "$type" | tr '[:upper:]-' '[:lower:]_')"
 
     case "$key" in
-        "idle_prompt"|"permission_prompt"|"auth_success"|"elicitation_dialog")
+        "idle_prompt"|"permission_prompt"|"auth_success"|"elicitation_dialog"|"ask_user")
             printf '%s\n' "$key"
             ;;
         "subagentstart"|"subagent_start")

--- a/lib/code-notify/core/notifier.sh
+++ b/lib/code-notify/core/notifier.sh
@@ -395,7 +395,7 @@ should_suppress_notification() {
 }
 
 # Check if notification should be suppressed
-if [[ "$HOOK_TYPE" == "stop" ]] || [[ "$HOOK_TYPE" == "notification" ]] || is_claude_event_hook; then
+if [[ "$HOOK_TYPE" == "stop" ]] || [[ "$HOOK_TYPE" == "notification" ]] || [[ "$HOOK_TYPE" == "PreToolUse" ]] || is_claude_event_hook; then
     if should_suppress_notification; then
         exit 0
     fi
@@ -476,8 +476,35 @@ case "$HOOK_TYPE" in
         SOUND="Glass"
         ;;
     "PreToolUse")
-        # Silent for PreToolUse - just log, no notification
-        exit 0
+        # AskUserQuestion: extract question text and show notification
+        ASK_QUESTION_TEXT=""
+        if has_jq; then
+            ASK_QUESTION_TEXT=$(printf '%s' "$HOOK_DATA" | jq -r '.tool_input.questions[0].question // ""' 2>/dev/null)
+        elif has_python3; then
+            ASK_QUESTION_TEXT=$(printf '%s' "$HOOK_DATA" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+    questions = data.get("tool_input", {}).get("questions", [])
+    print(questions[0]["question"] if questions else "", end="")
+except Exception:
+    print("", end="")
+' 2>/dev/null)
+        fi
+
+        TITLE="$TOOL_DISPLAY ❓"
+        SUBTITLE="Question"
+        if [[ -n "$ASK_QUESTION_TEXT" ]]; then
+            MESSAGE=$(printf '%s\n' "$ASK_QUESTION_TEXT" | head -c 150 | tr '\n' ' ')
+            MESSAGE="${MESSAGE% }"
+            if [[ ${#ASK_QUESTION_TEXT} -gt 150 ]]; then
+                MESSAGE="${MESSAGE}..."
+            fi
+        else
+            MESSAGE="$TOOL_DISPLAY is asking a question"
+        fi
+        VOICE_MESSAGE="$TOOL_DISPLAY is asking a question"
+        SOUND="Ping"
         ;;
     *)
         TITLE="$TOOL_DISPLAY 📢"


### PR DESCRIPTION
## Summary

- Add a new `ask_user` alert type that sends **immediate** desktop notifications when Claude Code uses `AskUserQuestion`, eliminating the 60-second wait of `idle_prompt`
- Register a `PreToolUse` hook with matcher `AskUserQuestion` to intercept questions before they're displayed
- Extract question text from the tool input and show it in the notification body (truncated to 150 chars)
- `cn alerts add ask_user` / `cn alerts remove ask_user` directly register/unregister the hook without needing `cn on`

## Problem

code-notify currently handles `idle_prompt` (AI idle for 60+ seconds) and `permission_prompt` (tool permission requests), but there's no notification for when Claude explicitly asks the user a question mid-conversation. This means users running Claude Code in the background won't know they need to respond until the 60-second idle timeout fires — if at all.

## Usage

```bash
cn alerts add ask_user     # Enable immediate question notifications
cn alerts remove ask_user  # Disable
```

No need to run `cn on` afterward — the hook is registered immediately.

## Technical Details

The `PreToolUse` hook infrastructure was already partially in place:
- `notifier.sh` had a `PreToolUse` case that silently exited
- `get_managed_claude_notification_pattern()` already included `PreToolUse` in its regex
- `has_legacy_global_claude_hooks()` already checked for `PreToolUse`

This PR activates the existing groundwork by:
1. **config.sh**: Add `ask_user` to `normalize_alert_type()`, add `register_ask_user_hook()` / `unregister_ask_user_hook()` with jq + python3 fallbacks (idempotent — strips existing entries before appending), wire into `enable_hooks_in_settings()` / `disable_hooks_in_settings()` and project-level equivalents
2. **notifier.sh**: Replace silent `PreToolUse` exit with question text extraction and notification dispatch, extend `should_suppress_notification` guard to include `PreToolUse` (respects kill switch and auto-accept)
3. **global.sh**: Add `ask_user` to `show_alerts_status()` and `show_available_alert_types()`, add direct hook registration in `add_alert_type()` / `remove_alert_type()` to avoid the `enable_single_tool` early-return path

## Test Plan

- [ ] `cn alerts add ask_user` registers PreToolUse hook with AskUserQuestion matcher in `~/.claude/settings.json`
- [ ] `cn alerts remove ask_user` removes the hook
- [ ] Running `cn alerts add ask_user` twice does not create duplicate entries (idempotent)
- [ ] When Claude Code calls `AskUserQuestion`, a desktop notification appears with the question text
- [ ] Kill switch (`cn off`) suppresses the notification
- [ ] `cn on` includes the PreToolUse hook when `ask_user` is enabled
- [ ] `cn off` removes the PreToolUse hook
- [ ] Works with both `jq` and `python3` fallback paths