### PR TITLE
fix: set UTF-8 input encoding for Windows stdin reading

### DIFF
--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -1654,6 +1654,7 @@ $LogFile = "$ClaudeHome\logs\notifications.log"
 $HookData = ""
 try {
     if ([Console]::IsInputRedirected) {
+        [Console]::InputEncoding = [System.Text.Encoding]::UTF8
         $HookData = [Console]::In.ReadToEnd()
     }
 } catch {


### PR DESCRIPTION
## Problem

On Windows systems with a non-UTF-8 system codepage, `notify.ps1` reads UTF-8 stdin from Claude Code hooks using `[Console]::In.ReadToEnd()`, which decodes bytes with the system codepage instead of UTF-8. This corrupts non-ASCII characters and breaks JSON parsing for any hook that receives non-ASCII data (e.g. `PreToolUse` with `AskUserQuestion` containing non-English text).

## Fix

Add one line before reading stdin:

```powershell
[Console]::InputEncoding = [System.Text.Encoding]::UTF8
```

## Testing

- Verified on Windows 11 that `PreToolUse` hooks with non-ASCII text in the JSON payload parse correctly after this fix
- Existing hooks (Stop, Notification) continue to work as before