### PR TITLE
chore: prepare v1.11.1 release

### DIFF
--- a/bin/code-notify
+++ b/bin/code-notify
@@ -6,7 +6,7 @@
 set -e
 
 # Version
-VERSION="1.11.0"
+VERSION="1.11.1"
 
 # Determine the directory where the script is located (resolve symlinks)
 SCRIPT_PATH="${BASH_SOURCE[0]}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-notify",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Desktop notifications and usage reset alerts for Claude Code, Codex CLI, Gemini CLI, Oh My Pi, and AI coding agents",
   "license": "MIT",
   "homepage": "https://github.com/mylee04/code-notify#readme",

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -20,7 +20,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 # Version
-$VERSION = "1.11.0"
+$VERSION = "1.11.1"
 
 # Colors and formatting
 function Write-Success { param([string]$Message) Write-Host "[OK] $Message" -ForegroundColor Green }
@@ -107,7 +107,7 @@ function Install-ClaudeNotify {
 # Code-Notify PowerShell Module
 # https://github.com/mylee04/code-notify
 
-$script:VERSION = "1.11.0"
+$script:VERSION = "1.11.1"
 $script:ClaudeHome = if ($env:CLAUDE_HOME) { $env:CLAUDE_HOME } else { "$env:USERPROFILE\.claude" }
 $script:DefaultSettingsFile = "$script:ClaudeHome\settings.json"
 $script:AlternateSettingsFile = "$env:USERPROFILE\.config\.claude\settings.json"


### PR DESCRIPTION
## Summary

- bump package version to 1.11.1
- align the Bash CLI and generated Windows runtime version constants
- prepare the patch release containing the Claude alert auto-apply fix from #58

## Validation

- ./scripts/run_tests.sh — 28/28 passed
- npm pack --dry-run — passed and reported code-notify@1.11.1
- Bash, package, and Windows version consistency check — passed

## Release follow-up

After merge, publish GitHub Release v1.11.1. The Trusted Publisher workflow will publish npm automatically; then update the external Homebrew tap with the release tarball SHA256.